### PR TITLE
Removed "Species" object

### DIFF
--- a/Poe整理倉庫v2/Poe整理倉庫v2.cfg
+++ b/Poe整理倉庫v2/Poe整理倉庫v2.cfg
@@ -13,7 +13,6 @@
     "Currency",
     "Ring",
     "Map",
-    "Species",
     "DivinationCard",
     "Leaguestone",
     "MiscMapItem",


### PR DESCRIPTION
Removed unnecessary "Species" object within the Species group would break the settings form, preventing the settings from loading.

This would throw a `System.ArgumentNullException: 'Value cannot be null.'` when the Settings Form (Form 3) is loaded, as it tries to fill the Type Listbox here: 

https://github.com/flier268/POE-Stash-Sorter-v2/blob/ad1525b4d85c2aab4e3bc23456fb7ef5381ec18d/Poe%E6%95%B4%E7%90%86%E5%80%89%E5%BA%ABv2/Form3.cs#L198-L203

